### PR TITLE
Fixed Vercel deployments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .idea
 node_modules
+.vercel
+.env

--- a/server/api/index.js
+++ b/server/api/index.js
@@ -24,21 +24,6 @@ app.get('/', async (req, res) => {
 //     res.send('Hello from DALL-E - another');
 // })
 
-const startServer = async () => {
+app.listen(3000, () => console.log('Server ready on port 3000.'));
 
-    try {
-        connectDB(process.env.MONGODB_URL);
-        app.listen(8080, () => console.log('Server started on ' +
-            'port http://localhost:8080'));
-    }
-
-    catch (error) {
-        console.log(error)
-    }
-
-
-
-}
-
-startServer();
-
+export default app;

--- a/server/api/index.ts
+++ b/server/api/index.ts
@@ -2,9 +2,9 @@ import express from "express";
 import * as dotenv from "dotenv";
 import cors from "cors";
 
-import connectDB from "./mongodb/connect.js";
-import postRoutes from "./routes/postRoutes.js";
-import dalleRoutes from "./routes/dalleRoutes.js";
+import connectDB from "../mongodb/connect.js";
+import postRoutes from "../routes/postRoutes.js";
+import dalleRoutes from "../routes/dalleRoutes.js";
 
 dotenv.config();
 

--- a/server/package.json
+++ b/server/package.json
@@ -2,10 +2,9 @@
   "name": "server",
   "version": "1.0.0",
   "description": "",
-  "type": "module",
-  "main": "index.js",
+  "main": "index.ts",
   "scripts": {
-    "start": "node ./index.js"
+    "start": "node api/index.ts"
   },
   "keywords": [],
   "author": "",

--- a/server/package.json
+++ b/server/package.json
@@ -2,9 +2,10 @@
   "name": "server",
   "version": "1.0.0",
   "description": "",
-  "main": "index.ts",
+  "type": "module",
+  "main": "index.js",
   "scripts": {
-    "start": "node api/index.ts"
+    "start": "node api/index.js"
   },
   "keywords": [],
   "author": "",

--- a/server/package.json
+++ b/server/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "index.js",
   "scripts": {
-    "start": "nodemon index"
+    "start": "node ./index.js"
   },
   "keywords": [],
   "author": "",

--- a/server/vercel.json
+++ b/server/vercel.json
@@ -1,0 +1,4 @@
+{
+  "version": 2,
+  "rewrites": [{ "source": "/(.*)", "destination": "/api" }]
+}


### PR DESCRIPTION
Fixed:
- Vercel deployments (missing default export from module);
- Simplified express listen definition.

Added:
- gitignore;
- Vercel config to redirect `/api` subpath to domain's root.

Changed:
- Added `api` catalog for better app structure.